### PR TITLE
[FEAT] 공용 Button 컴포넌트 추가

### DIFF
--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -1,0 +1,17 @@
+interface ButtonProps {
+  onClick?: () => void;
+  text: String;
+  type: "button" | "submit" | "reset";
+}
+
+export default function Button({ onClick, text, type }: ButtonProps) {
+  return (
+    <button
+      className="w-[343px] px-[10px] py-[16px] flex items-center justify-center gap-[10px]  bg-[#FF885A] rounded-xl font-sans text-white font-semibold text-[20px] leading-[22px] text-center"
+      onClick={onClick}
+      type={type}
+    >
+      {text}
+    </button>
+  );
+}


### PR DESCRIPTION
## PR 제목
[FEAT] 공용 Button 컴포넌트 추가

## PR을 한 이유
프로젝트 전반에서 재사용 가능한 버튼 컴포넌트를 도입하여
UI 일관성을 유지하고 중복 구현을 줄이기 위함입니다.

## #️⃣연관된 이슈
#2

## 📝작업 내용
- 공용 Button 컴포넌트 추가
- padding 기반 Hug 레이아웃 적용
- type, onClick props 처리
- Pretendard 폰트 및 기본 스타일 적용

### 스크린샷 
[
<img width="534" height="105" alt="image" src="https://github.com/user-attachments/assets/770301b2-8610-4e13-80c4-2753d316d74b" />
](url)

## 💬리뷰 요구사항
- 공용 컴포넌트 구조 및 props 설계가 적절한지 확인 부탁드립니다.
