### PR TITLE
[FEAT] 시작화면 UI 구현

### DIFF
--- a/src/components/splash/StartScreen.tsx
+++ b/src/components/splash/StartScreen.tsx
@@ -9,7 +9,7 @@ export default function SplashScreen() {
           alt="로그인 화면 로고"
           className="w-[211px] h-[84.1px]"
         />
-        <div className="text-center justify-start pt-[36px]">
+        <div className="text-center pt-[36px]">
           <span className="text-neutral-500 text-xs font-normal font-['Pretendard'] leading-4">
             모두의 식단 기호를 반영한 <br />
           </span>


### PR DESCRIPTION
## PR 제목
[FEAT] 시작화면 UI 구현

## PR을 한 이유
앱 실행 시 브랜드 아이덴티티를 자연스럽게 전달하고,
로그인 상태 확인 등 초기 로딩 구간에서 사용자에게 빈 화면이 보이지 않도록
시작 화면(Splash Screen)을 구현했습니다.

## #️⃣ 연관된 이슈
#17

## 📝 작업 내용
- 앱 시작 시 노출되는 Splash Screen UI 컴포넌트 구현
- 서비스 로고 및 소개 문구 배치
- 전체 화면 기준 중앙 정렬 레이아웃 적용
