### PR TITLE
[REFACTOR] to(경로) props 추가

### DIFF
--- a/src/components/header/PublicHeader.tsx
+++ b/src/components/header/PublicHeader.tsx
@@ -1,13 +1,15 @@
+import type { To } from "react-router-dom";
 import BackButton from "../common/BackButton";
 
 interface PublicHeaderProps {
   title: string | null;
+  to?: number | To;
 }
 
-const PublicHeader = ({ title }: PublicHeaderProps) => {
+const PublicHeader = ({ title, to }: PublicHeaderProps) => {
   return (
     <div className="w-full px-4 py-2.5 flex justify-between items-center">
-      <BackButton />
+      <BackButton to={to} />
       <div className="">
         <p className="justify-start text-black text-xl font-semibold font-['Pretendard'] tracking-tight">
           {title}


### PR DESCRIPTION
## PR 제목
[REFACTOR] to(경로) props 추가

## PR을 한 이유
PublicHeader의 뒤로가기 버튼 동작을 페이지마다 유연하게 제어할 수 있는 기능을 추가합니다.

## #️⃣연관된 이슈

> #49 

## 📝작업 내용

- 인터페이스에 to(이동하고 싶은 경로) 추가
- BackButton에 to props 내려주기


## 💬리뷰 요구사항(선택)

> 페이지 이동이 잘 되는지 확인 부탁드립니다!
