### PR TITLE
[BUGFIX] 헤더에서 마이페이지 라우팅 오류 해결

### DIFF
--- a/src/components/header/HomeHeader.tsx
+++ b/src/components/header/HomeHeader.tsx
@@ -24,7 +24,7 @@ const HomeHeader = () => {
             src={accountImg}
             alt="마이페이지 아이콘"
             className="w-6 h-6"
-            onClick={() => navigate("mypage")}
+            onClick={() => navigate("/mypage")}
           />
         </div>
       </div>


### PR DESCRIPTION
## PR 제목
[BUGFIX] 헤더에서 마이페이지 라우팅 오류 해결

## PR을 한 이유
홈 이외의 페이지 헤더에서 마이페이지를 누르면 라우팅 오류가 생기는 문제 수정

## #️⃣연관된 이슈

> closed #63 

## 📝작업 내용

> useNavigate()의 괄호 안을 `'/mypage'` 절대경로로 수정했음


## 💬리뷰 요구사항(선택)

> 기대한대로 동작하는지 확인해주시면 감사하겠습니다!
