### PR TITLE
[BUGFIX] .map() 사용 전 방어 코드 추가

### DIFF
--- a/src/pages/mypage/notice-page.tsx
+++ b/src/pages/mypage/notice-page.tsx
@@ -8,7 +8,7 @@ export default function NoticePage() {
     <>
       <PublicHeader title={"알림 내용"} />
       <div className="pt-[66px] flex flex-col items-center mx-auto gap-[12px] w-[343px]">
-        {noticeList.noticeList?.notices.map((notice) => (
+        {noticeList.noticeList?.notices?.map((notice) => (
           <NoticeBlock
             key={notice.id}
             icon={notice.icon}


### PR DESCRIPTION
## PR 제목
[BUGFIX] .map() 사용 전 방어 코드 추가

## PR을 한 이유
.map() 사용할때 방어코드 (notices?.map())을 사용하지 않아 페이지가 제대로 렌더링 되지 않는 이슈 발생

## #️⃣연관된 이슈

> #71 
