### PR TITLE
[REFACTOR] 식단 생성/조회 ux개선 

### DIFF
--- a/src/components/meal-plan/MealPlanResult.tsx
+++ b/src/components/meal-plan/MealPlanResult.tsx
@@ -13,6 +13,7 @@ type MealPlanResultProps = {
   mealPlanId: number;
   onClick: () => void;
   weekParam: string | null;
+  isLoading;
 };
 
 type mealPlanResponse = Record<string, SlotItem[]>;
@@ -30,11 +31,13 @@ export default function MealPlanResult({
   mealPlanId,
   onClick,
   weekParam,
+  isLoading,
 }: MealPlanResultProps) {
   const navigate = useNavigate();
   const [isOpen, setIsOpen] = useState(false);
 
   const response = sessionStorage.getItem("mealPlan");
+  if (isLoading) return null;
   if (!response) {
     toast.error("올바른 접근이 아닙니다. 식단 생성부터 해주세요!");
     return;

--- a/src/components/meal-plan/MealPlanResult.tsx
+++ b/src/components/meal-plan/MealPlanResult.tsx
@@ -13,7 +13,7 @@ type MealPlanResultProps = {
   mealPlanId: number;
   onClick: () => void;
   weekParam: string | null;
-  isLoading;
+  isLoading: boolean;
 };
 
 type mealPlanResponse = Record<string, SlotItem[]>;

--- a/src/components/meal-plan/MenuChip.tsx
+++ b/src/components/meal-plan/MenuChip.tsx
@@ -18,7 +18,7 @@ export default function MenuChip({
     ${clickable ? "cursor-pointer" : ""}`}
       onClick={clickable ? onClick : undefined}
     >
-      {text}
+      <span className="line-clamp-3">{text}</span>
     </div>
   );
 }

--- a/src/components/meal-plan/ReviewModal.tsx
+++ b/src/components/meal-plan/ReviewModal.tsx
@@ -5,7 +5,7 @@ import UnselectedStar from "../../assets/icons/star-unselected.svg";
 import SelectedStar from "../../assets/icons/star-selected.svg";
 import AlertModal from "../common/AlertModal";
 import type { createReview } from "../../types/review";
-import usePostReview from "../../hooks/use-post-review";
+import usePostReview from "../../hooks/mutations/use-post-review";
 import toast from "react-hot-toast";
 
 type ReviewModalProps = {

--- a/src/hooks/mutations/use-post-review.ts
+++ b/src/hooks/mutations/use-post-review.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { postReview, postTransformReview } from "../api/review";
-import { formatYMD } from "../utils/date";
-import type { createReview } from "../types/review";
+import { postReview, postTransformReview } from "../../api/review";
+import { formatYMD } from "../../utils/date";
+import type { createReview } from "../../types/review";
 
 export type review = createReview & { type: "RECIPE" | "TRANSFORMED_RECIPE" };
 function usePostReview() {

--- a/src/hooks/queries/use-get-today-meal-plan.ts
+++ b/src/hooks/queries/use-get-today-meal-plan.ts
@@ -9,6 +9,7 @@ function useGetTodayMealPlan(familyRoomId: number | null) {
     queryKey: ["mealplan", "today", today, familyRoomId],
 
     enabled: !!familyRoomId,
+    retry: 1,
     staleTime: Infinity, //같은 날에 바뀔 일은 거의 없어서 무한으로 두었습니다.
     gcTime: 1000 * 60 * 60, //1시간
   });

--- a/src/hooks/queries/use-get-week-meal.ts
+++ b/src/hooks/queries/use-get-week-meal.ts
@@ -9,6 +9,7 @@ function useGetWeekMealPlan(familyRoomId: number, date: string) {
     queryFn: () => getWeekMealPlan({ familyRoomId: familyRoomId!, date }),
     queryKey: ["mealplan", "week", today, date, familyRoomId],
     enabled: !!familyRoomId,
+    retry: 1,
     staleTime: Infinity, //같은 날에 바뀔 일은 거의 없어서 무한으로 두었습니다.
     gcTime: 1000 * 60 * 60, //1시간
   });

--- a/src/pages/meal-plan/meal-plan-create-page.tsx
+++ b/src/pages/meal-plan/meal-plan-create-page.tsx
@@ -13,11 +13,12 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 import { getNextMonday, getThisMonday } from "../../utils/date";
 import { LoadingSpinner } from "../../components/common/LoadingSpinner";
 import toast from "react-hot-toast";
+import { useProfileStore } from "../../stores/use-profile-store";
 
 const MealPlanCreatePage = () => {
   const [step, setStep] = useState<"create" | "result">("create");
   const [isOpen, setIsOpen] = useState(false);
-  const isMember = false; // true로 바꾸면 가족원 화면을 볼 수 있습니다.
+  const isLeader = useProfileStore().isLeader;
   const { familyRoomId } = useFamilyStore.getState();
   const navigate = useNavigate();
   const [isLoading, setIsLoading] = useState(false);
@@ -76,7 +77,7 @@ const MealPlanCreatePage = () => {
 
   return (
     <div>
-      {isMember ? (
+      {!isLeader ? (
         <>
           <PublicHeader title={"식단 생성"} />
           <MemberMealPlanView />

--- a/src/pages/meal-plan/meal-plan-create-page.tsx
+++ b/src/pages/meal-plan/meal-plan-create-page.tsx
@@ -33,6 +33,8 @@ const MealPlanCreatePage = () => {
   const regenerate = true;
 
   const handleCreate = async () => {
+    if (step === "create") setStep("result");
+
     const body: CreateMealPlan = {
       weekStartDate: weekParam === "THIS" ? getThisMonday() : getNextMonday(),
       selectedSlots: [...lunchSlots, ...dinnerSlots],
@@ -59,13 +61,13 @@ const MealPlanCreatePage = () => {
         "mealPlanId",
         JSON.stringify(response.result.mealPlanId),
       );
-      if (step === "create") setStep("result");
     } catch (error: any) {
       if (error.response?.data?.code === "MEAL_PLAN_409") {
         toast.error("이미 생성된 다음주 식단이 있어요");
       } else {
         toast.error(error.response?.data?.message);
       }
+      setStep("create");
       navigate(`/`);
     } finally {
       setIsLoading(false); // 로딩 끝
@@ -137,6 +139,7 @@ const MealPlanCreatePage = () => {
                   mealPlanId={mealPlanId}
                   onClick={handleCreate}
                   weekParam={weekParam}
+                  isLoading={isLoading}
                 />
               )}
             </div>


### PR DESCRIPTION
## PR 제목
[REFACTOR] 식단 생성/조회 ux개선 

## #️⃣연관된 이슈

> #183 

## 📝작업 내용

- 불필요한 서버 호출 방지를 위해 조회 쿼리에 retry:1 설정
- 식단 생성할 때 보이지 않던 로딩스피너 오류 수정
- 식단 생성 페이지에서 방장이 아닌 경우 분기처리 
- 식단 카드 3줄 초과 시 숨김 처리 

## 💬리뷰 요구사항(선택)

로그인 리다이렉트가 배포 주소로 변경되어 오류를 바로 확인할 수 없을 것 같습니다
main머지 후 여전히 문제가 있다면 다시 고치겠습니다. 
