### PR TITLE
[FEAT] 프록시 설정 & 리프레시 토큰 인터셉터 추가

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,13 +1,20 @@
+import axios from "axios";
 import type { LogoutResponse, ReissueResponse } from "../types/auth";
-import { axiosInstance } from "./axios/axios";
 
 export const postReissue = async (): Promise<ReissueResponse> => {
-  const { data } =
-    await axiosInstance.post<ReissueResponse>("/api/auth/reissue");
+  const { data } = await axios.post<ReissueResponse>(
+    `${import.meta.env.VITE_API_BASE_URL}/api/auth/reissue`,
+    {
+      withCredentials: true,
+    },
+  );
   return data;
 };
 
 export const postLogout = async (): Promise<LogoutResponse> => {
-  const { data } = await axiosInstance.post<LogoutResponse>("/api/auth/logout");
+  const { data } = await axios.post<LogoutResponse>(
+    `${import.meta.env.VITE_API_BASE_URL}/api/auth/logout`,
+    { withCredentials: true },
+  );
   return data;
 };

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,16 +1,13 @@
-import axios from "axios";
 import type { LogoutResponse, ReissueResponse } from "../types/auth";
+import { axiosInstance } from "./axios/axios";
 
 export const postReissue = async (): Promise<ReissueResponse> => {
-  const { data } = await axios.post<ReissueResponse>(
-    `${import.meta.env.VITE_API_BASE_URL}/api/auth/reissue`,
-  );
+  const { data } =
+    await axiosInstance.post<ReissueResponse>("/api/auth/reissue");
   return data;
 };
 
 export const postLogout = async (): Promise<LogoutResponse> => {
-  const { data } = await axios.post<LogoutResponse>(
-    `${import.meta.env.VITE_API_BASE_URL}/api/auth/logout`,
-  );
+  const { data } = await axiosInstance.post<LogoutResponse>("/api/auth/logout");
   return data;
 };

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -4,6 +4,7 @@ import type { LogoutResponse, ReissueResponse } from "../types/auth";
 export const postReissue = async (): Promise<ReissueResponse> => {
   const { data } = await axios.post<ReissueResponse>(
     `${import.meta.env.VITE_API_BASE_URL}/api/auth/reissue`,
+    {},
     {
       withCredentials: true,
     },
@@ -14,6 +15,7 @@ export const postReissue = async (): Promise<ReissueResponse> => {
 export const postLogout = async (): Promise<LogoutResponse> => {
   const { data } = await axios.post<LogoutResponse>(
     `${import.meta.env.VITE_API_BASE_URL}/api/auth/logout`,
+    {},
     { withCredentials: true },
   );
   return data;

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -4,8 +4,6 @@ import type { LogoutResponse, ReissueResponse } from "../types/auth";
 export const postReissue = async (): Promise<ReissueResponse> => {
   const { data } = await axios.post<ReissueResponse>(
     `${import.meta.env.VITE_API_BASE_URL}/api/auth/reissue`,
-    {},
-    { withCredentials: true },
   );
   return data;
 };
@@ -13,8 +11,6 @@ export const postReissue = async (): Promise<ReissueResponse> => {
 export const postLogout = async (): Promise<LogoutResponse> => {
   const { data } = await axios.post<LogoutResponse>(
     `${import.meta.env.VITE_API_BASE_URL}/api/auth/logout`,
-    {},
-    { withCredentials: true },
   );
   return data;
 };

--- a/src/api/axios/axios.ts
+++ b/src/api/axios/axios.ts
@@ -46,7 +46,7 @@ axiosInstance.interceptors.response.use(
       try {
         const reissueRes = await postReissue();
 
-        const { setItem } = useLocalStorage(reissueRes.result.accessToken);
+        const { setItem } = useLocalStorage(LOCAL_STORAGE_KEY.accessToken);
         setItem(reissueRes.result.accessToken);
         originalRequest.headers.Authorization = `Bearer ${reissueRes.result.accessToken}`;
         if (reissueRes.result.needAgreement) {

--- a/src/api/axios/axios.ts
+++ b/src/api/axios/axios.ts
@@ -4,8 +4,11 @@ import { LOCAL_STORAGE_KEY } from "../../constants/key";
 import { postLogout, postReissue } from "../auth";
 import toast from "react-hot-toast";
 
+const isDev = import.meta.env.DEV;
+const BASE_URL = isDev ? "" : import.meta.env.VITE_API_BASE_URL;
+
 export const axiosInstance = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL || "",
+  baseURL: BASE_URL,
   withCredentials: true,
   headers: {
     "Content-Type": "application/json",

--- a/src/api/axios/axios.ts
+++ b/src/api/axios/axios.ts
@@ -1,9 +1,15 @@
 import axios from "axios";
 import { useLocalStorage } from "../../hooks/use-local-storage";
 import { LOCAL_STORAGE_KEY } from "../../constants/key";
+import { postLogout, postReissue } from "../auth";
+import toast from "react-hot-toast";
 
 export const axiosInstance = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL || "",
+  withCredentials: true,
+  headers: {
+    "Content-Type": "application/json",
+  },
 });
 
 // 요청 인터셉터: 모든 요청 전에 accessToken을 Authorization 헤더에 추가
@@ -23,4 +29,41 @@ axiosInstance.interceptors.request.use(
   },
   // 요청 인터셉터가 실패하면, 에러 뿜음
   (error) => Promise.reject(error),
+);
+
+// 응답 인터셉터
+axiosInstance.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config;
+
+    // 401에러 & 재시도 X
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true;
+
+      try {
+        const reissueRes = await postReissue();
+
+        originalRequest.headers.Authorization = `Bearer ${reissueRes.result.accessToken}`;
+        if (reissueRes.result.needAgreement) {
+          // 약관동의 안 돼있을 경우 약관동의로 리다이렉트
+          window.location.href = "/agreement";
+        }
+        return axiosInstance(originalRequest);
+      } catch (refreshError) {
+        // 리프레시 토큰 만료
+        toast.error("세션이 만료되었습니다. 다시 로그인해주세요.");
+
+        try {
+          await postLogout();
+        } catch (logoutError) {
+          toast.error("로그아웃 API 호출 실패");
+        } finally {
+          localStorage.removeItem(LOCAL_STORAGE_KEY.accessToken);
+          window.location.href = "/login";
+        }
+      }
+    }
+    return Promise.reject(error);
+  },
 );

--- a/src/api/axios/axios.ts
+++ b/src/api/axios/axios.ts
@@ -9,7 +9,6 @@ const BASE_URL = isDev ? "" : import.meta.env.VITE_API_BASE_URL;
 
 export const axiosInstance = axios.create({
   baseURL: BASE_URL,
-  withCredentials: true,
   headers: {
     "Content-Type": "application/json",
   },

--- a/src/api/axios/axios.ts
+++ b/src/api/axios/axios.ts
@@ -19,7 +19,7 @@ export const axiosInstance = axios.create({
 axiosInstance.interceptors.request.use(
   (config) => {
     const { getItem } = useLocalStorage(LOCAL_STORAGE_KEY.accessToken);
-    let accessToken = getItem();
+    const accessToken = getItem();
 
     // accessToken이 존재하면 Authorization 헤더에 Bearer 토큰 형식으로 추가한다
     if (accessToken) {

--- a/src/api/axios/axios.ts
+++ b/src/api/axios/axios.ts
@@ -53,6 +53,7 @@ axiosInstance.interceptors.response.use(
         if (reissueRes.result.needAgreement) {
           // 약관동의 안 돼있을 경우 약관동의로 리다이렉트
           window.location.href = "/agreement";
+          return Promise.reject(new Error("Agreement required"));
         }
         return axiosInstance(originalRequest);
       } catch (refreshError) {

--- a/src/api/axios/axios.ts
+++ b/src/api/axios/axios.ts
@@ -3,7 +3,7 @@ import { useLocalStorage } from "../../hooks/use-local-storage";
 import { LOCAL_STORAGE_KEY } from "../../constants/key";
 
 export const axiosInstance = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL,
+  baseURL: import.meta.env.VITE_API_BASE_URL || "",
 });
 
 // 요청 인터셉터: 모든 요청 전에 accessToken을 Authorization 헤더에 추가

--- a/src/api/axios/axios.ts
+++ b/src/api/axios/axios.ts
@@ -47,6 +47,8 @@ axiosInstance.interceptors.response.use(
       try {
         const reissueRes = await postReissue();
 
+        const { setItem } = useLocalStorage(reissueRes.result.accessToken);
+        setItem(reissueRes.result.accessToken);
         originalRequest.headers.Authorization = `Bearer ${reissueRes.result.accessToken}`;
         if (reissueRes.result.needAgreement) {
           // 약관동의 안 돼있을 경우 약관동의로 리다이렉트

--- a/src/pages/auth/signup-page.tsx
+++ b/src/pages/auth/signup-page.tsx
@@ -1,5 +1,0 @@
-const SignupPage = () => {
-  return <div>SignupPage 입니다.</div>;
-};
-
-export default SignupPage;

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,7 +1,6 @@
 import { createBrowserRouter } from "react-router-dom";
 import MobileLayout from "../layouts/mobile-layout";
 import ProtectedRoute from "./protected-route";
-import SignupPage from "../pages/auth/signup-page";
 import LoginPage from "../pages/auth/login-page";
 import HomePage from "../pages/home/home-page";
 import MyPage from "../pages/mypage/my-page";
@@ -46,10 +45,6 @@ export const router = createBrowserRouter([
       {
         path: "login/callback",
         element: <LoginRedirectPage />,
-      },
-      {
-        path: "signup",
-        element: <SignupPage />,
       },
       {
         path: "agreement",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,21 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [react(), tailwindcss()],
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), "");
+
+  return {
+    plugins: [react(), tailwindcss()],
+    server: {
+      proxy: {
+        // '/api'로 시작하는 모든 요청을 프록시가 가로챔
+        "/api": {
+          target: env.VITE_API_BASE_URL,
+          changeOrigin: true,
+        },
+      },
+    },
+  };
 });


### PR DESCRIPTION
## PR 제목
[FEAT] 프록시 설정 & 리프레시 토큰 인터셉터 추가

## PR을 한 이유
- CORS 에러 방지를 위한 프록시 설정 -> 개발환경에서도 api 접근이 가능하도록
- 리프레시 토큰 인터셉터 추가 & 로그아웃 후 로그인으로 리다이렉트 하도록 로직 개선

## #️⃣연관된 이슈

> closed #219 

## 📝작업 내용

> - proxy 설정을 했습니다. env파일 그대로 냅두시고 사용하시면 됩니다.
----
> - accessToken이 없을 때, refreshToken을 이용해서 reissue를 하도록 했습니다.
----
> 만약 리프레시 토큰을 통해 액세스 토큰을 받았을 경우에
> if(약관동의 안돼있을 경우) => 약관동의 화면으로 리다이렉트
> 
> 리프레시 토큰이 없을 경우
> 로그아웃 진행 -> 로그아웃 실패시 세션을 제거하고 로그인 페이지로 리다이렉트

## 💬리뷰 요구사항(선택)

> 코드리뷰, 컨벤션, 사용자 플로우가 정확한지 확인해주시면 감사하겠습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 만료된 세션 자동 재발급 및 원래 요청 재시도 처리
  * 세션 만료 시 사용자 대상 알림(토스트) 표시

* **변경 사항**
  * 회원가입 페이지 및 관련 라우트 제거(더 이상 /signup 접근 불가)
  * 환경(mode) 기반 API 엔드포인트 및 개발용 프록시 구성 지원 추가
  * 기본 요청 헤더(Content-Type: application/json) 및 인증 토큰 자동 첨부 처리 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->